### PR TITLE
fix: remove defunct generate-store-icons step from release pipelines

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,10 +83,6 @@ jobs:
           includeDebug: false
           args: --target ${{ matrix.target }}
 
-      - name: Generate store icons
-        shell: pwsh
-        run: .\scripts\generate-store-icons.ps1
-
       - name: Convert version to MSIX format
         id: msix-version
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,6 @@ jobs:
           includeDebug: false
           args: --target ${{ matrix.target }}
 
-      - name: Generate store icons
-        shell: pwsh
-        run: .\scripts\generate-store-icons.ps1
-
       - name: Convert version to MSIX format
         id: msix-version
         shell: pwsh

--- a/scripts/build-msix.ps1
+++ b/scripts/build-msix.ps1
@@ -82,7 +82,7 @@ if (Test-Path $WebView2Loader) {
 }
 
 # Copy icons/assets - these must be exact sizes per Microsoft Store requirements
-# Run generate-store-icons.ps1 first to ensure correct sizes
+# Run `npm run generate:icons` first if regenerating from SVG source
 $RequiredAssets = @(
     # Base tile icons (referenced in AppxManifest.xml)
     "Square44x44Logo.png",   # 44x44 - required
@@ -110,7 +110,7 @@ foreach ($asset in $RequiredAssets) {
 }
 
 if ($missingAssets.Count -gt 0) {
-    Write-Host "WARNING: Missing $($missingAssets.Count) icon(s) - run generate-store-icons.ps1 first" -ForegroundColor Yellow
+    Write-Host "WARNING: Missing $($missingAssets.Count) icon(s) - run 'npm run generate:icons' first" -ForegroundColor Yellow
     foreach ($missing in $missingAssets) {
         Write-Host "  - $missing" -ForegroundColor Yellow
     }


### PR DESCRIPTION
All icons are now pre-generated from SVG source and committed to the repo. The release workflows referenced a deleted PowerShell script (generate-store-icons.ps1) causing the v0.16.0 build to fail.