### PR TITLE
fix: Sync language preference to localStorage for persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,9 @@ function App() {
     const targetLang = locale === "auto"
       ? resolveLanguage(navigator.language)
       : locale;
+    // Sync localStorage so i18next LanguageDetector uses the correct language
+    // on next startup before Tauri settings load asynchronously
+    localStorage.setItem("wsl-ui-language", targetLang);
     if (i18n.language !== targetLang) {
       loadLanguage(targetLang).then(() => i18n.changeLanguage(targetLang));
     }

--- a/src/components/settings/LanguageSettings.tsx
+++ b/src/components/settings/LanguageSettings.tsx
@@ -20,15 +20,16 @@ export function LanguageSettings() {
   const handleLanguageChange = async (locale: string) => {
     await updateSetting("locale", locale);
 
-    if (locale === "auto") {
-      // Reset to browser-detected language
-      const targetLang = resolveLanguage(navigator.language || "en");
-      await loadLanguage(targetLang);
-      i18n.changeLanguage(targetLang);
-    } else {
-      await loadLanguage(locale);
-      i18n.changeLanguage(locale);
-    }
+    const targetLang = locale === "auto"
+      ? resolveLanguage(navigator.language || "en")
+      : locale;
+
+    // Sync to localStorage so i18next LanguageDetector restores the correct
+    // language on next startup (before Tauri settings are loaded asynchronously)
+    localStorage.setItem("wsl-ui-language", targetLang);
+
+    await loadLanguage(targetLang);
+    i18n.changeLanguage(targetLang);
 
     // Set RTL direction for Arabic
     const langConfig = supportedLanguages.find((l) => l.code === (locale === "auto" ? i18n.language : locale));


### PR DESCRIPTION
## Summary
- Explicitly sync the resolved language to `localStorage` when the user changes language and when settings load on startup
- Fixes a race condition where i18next's LanguageDetector ran before Tauri backend settings loaded, causing the language to revert to English on restart

Closes #39

## Test plan
- [ ] Change language to a non-English locale, restart the app, verify it persists
- [ ] Set language to "Auto", restart, verify browser-detected language is used
- [ ] Verify RTL (Arabic) still works correctly after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)