### PR TITLE
fix(install-dialog): make dialog scale to viewport on small displays (OCT-941)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1069,6 +1069,38 @@ The following language codes are supported:
 
 ---
 
+## Issue #14: New distribution dialog clips off-screen on small displays
+
+### Symptoms
+- User clicks the "New" button (or any control opening the install dialog) on a display shorter than ~525px of available height
+- Dialog opens centered, but the close button at the top and/or the Cancel/Install action buttons at the bottom are clipped off-screen
+- Page does not scroll, so there is no way to reach the clipped controls
+- User reported "opens a new unscrollable window that makes it impossible to do anything"
+
+### Root Cause
+`src/components/NewDistroDialog.tsx` set the dialog container to `h-[95vh] min-h-[500px]`. The `min-h-[500px]` floor forced the dialog taller than the viewport on short displays. Because the outer overlay used `flex items-center justify-center` with no `overflow-y-auto`, the over-sized dialog was centered and clipped equally at top and bottom, with no scrollable scrollbar to recover the hidden parts.
+
+Other dialogs in the codebase (`HelpDialog`, `DistroInfoDialog`, `QuickActionsMenu`, etc.) use `max-h-[NNvh]` only and so scaled correctly with the viewport. NewDistroDialog was the outlier.
+
+### Diagnosis
+1. Resize the app window so its content area is below ~525 px tall.
+2. Open the install dialog.
+3. Observe missing close button and missing footer action buttons.
+
+### Solution
+**Fix applied in code (`src/components/NewDistroDialog.tsx:577-589`):**
+- Removed `h-[95vh]` (forced height) and `min-h-[500px]` (overflow floor).
+- Replaced with `max-h-[calc(100vh-2rem)]` so the dialog grows with content but never exceeds the viewport (minus 2rem of breathing room matching the new outer padding).
+- Added `overflow-y-auto py-4` to the outer `fixed inset-0` overlay as a safety net so that on extreme small heights (e.g. 200 px) the user can still scroll to reach the footer.
+
+### Files Changed
+- `src/components/NewDistroDialog.tsx`: Outer overlay made scrollable with vertical padding; dialog uses `max-h-[calc(100vh-2rem)]` instead of `h-[95vh] min-h-[500px]`.
+
+### Related
+- Original report: Paperclip issue OCT-941
+
+---
+
 ## Template for New Issues
 
 ```markdown

--- a/src/components/NewDistroDialog.tsx
+++ b/src/components/NewDistroDialog.tsx
@@ -574,7 +574,7 @@ export function NewDistroDialog({ isOpen, onClose }: NewDistroDialogProps) {
 
   return (
     <Portal>
-      <div className="fixed inset-0 z-[100] flex items-center justify-center">
+      <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto py-4">
         {/* Backdrop */}
         <div
           className="absolute inset-0 bg-theme-bg-primary/85 backdrop-blur-sm transition-opacity"
@@ -586,7 +586,7 @@ export function NewDistroDialog({ isOpen, onClose }: NewDistroDialogProps) {
           role="dialog"
           aria-modal="true"
           data-testid="new-distro-dialog"
-          className="relative bg-theme-bg-secondary border border-theme-border-secondary rounded-2xl shadow-2xl shadow-black/50 max-w-4xl w-full mx-4 h-[95vh] min-h-[500px] flex flex-col overflow-hidden animate-fade-slide-in"
+          className="relative bg-theme-bg-secondary border border-theme-border-secondary rounded-2xl shadow-2xl shadow-black/50 max-w-4xl w-full mx-4 max-h-[calc(100vh-2rem)] flex flex-col overflow-hidden animate-fade-slide-in"
         >
           {/* Top accent line */}
           <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-theme-accent-primary/50 to-transparent" />


### PR DESCRIPTION
## Summary
- Removes `h-[95vh] min-h-[500px]` on the New Distribution dialog, replacing it with `max-h-[calc(100vh-2rem)]` so the dialog scales to short viewports instead of overflowing them.
- Makes the outer overlay `overflow-y-auto py-4` as a safety net so the dialog remains reachable even on extreme small heights (was previously clipped at top and bottom with no way to scroll).
- Documents the bug and fix in `docs/TROUBLESHOOTING.md` (Issue #12).

## Why
User report on OCT-941: clicking the install button opened a dialog whose close button and footer action buttons were both clipped off-screen on a small display, with no way to scroll. Root cause was the `min-h-[500px]` floor forcing the dialog taller than the viewport while the surrounding `flex items-center justify-center` overlay had no scroll. Other dialogs in this codebase (`HelpDialog`, `DistroInfoDialog`, `QuickActionsMenu`) already use `max-h-[NNvh]`-only — this brings `NewDistroDialog` in line.

## Test plan
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Existing `NewDistroDialog.test.tsx` suite passes (7/7)
- [ ] Manual: resize app window below ~525 px tall, open install dialog, verify close button and footer Cancel/Install buttons are reachable; verify scroll works inside the content area when dialog is at max height
- [ ] Manual: at normal window height, dialog still looks visually identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)