### PR TITLE
feat(OCT-445): periodically refresh distro diskSize

### DIFF
--- a/src/store/distroStore.test.ts
+++ b/src/store/distroStore.test.ts
@@ -842,6 +842,107 @@ describe("distroStore", () => {
       // Alpine returns a real size
       expect(alpine?.diskSize).toBe(1024 * 1024);
     });
+
+    it("does not refetch diskSize on subsequent fetches when cache is fresh", async () => {
+      vi.mocked(wslService.listDistributions).mockResolvedValue(
+        mockDistributions
+      );
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(
+        1024 * 1024 * 1024
+      );
+
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Cleared on the first fetch — all three distros queried once.
+      expect(wslService.getDistributionDiskSize).toHaveBeenCalledTimes(3);
+      vi.mocked(wslService.getDistributionDiskSize).mockClear();
+
+      // Second fetch immediately after — cache is fresh, no refetch.
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wslService.getDistributionDiskSize).not.toHaveBeenCalled();
+    });
+
+    it("refetches diskSize when cache is older than the refresh interval", async () => {
+      vi.mocked(wslService.listDistributions).mockResolvedValue(
+        mockDistributions
+      );
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(
+        1024 * 1024 * 1024
+      );
+
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Backdate diskSizeLastFetched past the refresh interval.
+      const stale = Date.now() - (5 * 60 * 1000 + 1000);
+      useDistroStore.setState({
+        distributions: useDistroStore
+          .getState()
+          .distributions.map((d) => ({ ...d, diskSizeLastFetched: stale })),
+      });
+
+      vi.mocked(wslService.getDistributionDiskSize).mockClear();
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(
+        2 * 1024 * 1024 * 1024
+      );
+
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // All three distros refetched.
+      expect(wslService.getDistributionDiskSize).toHaveBeenCalledTimes(3);
+
+      // New value should be reflected in the store.
+      const ubuntu = useDistroStore
+        .getState()
+        .distributions.find((d) => d.name === "Ubuntu");
+      expect(ubuntu?.diskSize).toBe(2 * 1024 * 1024 * 1024);
+    });
+
+    it("refetches diskSize when diskSizeLastFetched is missing even if diskSize is set", async () => {
+      // Distribution data hydrated from somewhere without a timestamp
+      // (e.g. older persisted state, or test seeding) should still refetch.
+      vi.mocked(wslService.listDistributions).mockResolvedValue(
+        mockDistributions
+      );
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(
+        1024 * 1024
+      );
+
+      useDistroStore.setState({
+        distributions: mockDistributions.map((d) => ({
+          ...d,
+          diskSize: 999,
+          // diskSizeLastFetched intentionally omitted
+        })),
+      });
+
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wslService.getDistributionDiskSize).toHaveBeenCalledTimes(3);
+    });
+
+    it("records diskSizeLastFetched alongside diskSize on successful fetch", async () => {
+      vi.mocked(wslService.listDistributions).mockResolvedValue(
+        mockDistributions
+      );
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(2048);
+
+      const before = Date.now();
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const after = Date.now();
+
+      for (const d of useDistroStore.getState().distributions) {
+        expect(d.diskSize).toBe(2048);
+        expect(d.diskSizeLastFetched).toBeGreaterThanOrEqual(before);
+        expect(d.diskSizeLastFetched).toBeLessThanOrEqual(after);
+      }
+    });
   });
 
   describe("race condition handling", () => {

--- a/src/store/distroStore.ts
+++ b/src/store/distroStore.ts
@@ -57,6 +57,12 @@ interface DistroStore {
 // Request ID counter to track and invalidate stale requests
 let currentFetchId = 0;
 
+// Refresh diskSize values older than this. Disk usage drifts over time
+// (compaction, writes inside the distro) but doesn't need polling at the
+// 10s list cadence — a periodic refresh keeps the UI honest without
+// spamming WSL.
+export const DISK_SIZE_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 // Helper to detect timeout errors from backend
 const isTimeoutErrorMessage = (error: string): boolean => {
   return error.toLowerCase().includes("timed out") ||
@@ -98,6 +104,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
           return {
             ...newDistro,
             diskSize: existing.diskSize,
+            diskSizeLastFetched: existing.diskSizeLastFetched,
             osInfo: existing.osInfo,
             metadata: existing.metadata,
           };
@@ -111,7 +118,14 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
       // Fetch disk sizes and OS info in background (don't block the UI).
       // Only fetch details that are not already cached to avoid flooding WSL
       // with commands on every 10-second poll cycle.
-      const distrosMissingDiskSize = distributions.filter((d) => d.diskSize === undefined);
+      // diskSize is refreshed if older than DISK_SIZE_REFRESH_INTERVAL_MS so
+      // the displayed value stays accurate as the VHDX grows or is compacted.
+      const now = Date.now();
+      const distrosMissingDiskSize = distributions.filter((d) => {
+        if (d.diskSize === undefined) return true;
+        if (d.diskSizeLastFetched === undefined) return true;
+        return now - d.diskSizeLastFetched >= DISK_SIZE_REFRESH_INTERVAL_MS;
+      });
       const distrosMissingOsInfo = distributions.filter(
         (d) => d.state === "Running" && !d.osInfo
       );
@@ -138,6 +152,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
           // Zero IS stored — it means "VHDX not found" and caching it prevents an
           // infinite refetch loop for distros with non-standard install paths.
           if (fetchId === currentFetchId && diskSize >= 0) {
+            const fetchedAt = Date.now();
             set((state) => {
               const distroExists = state.distributions.some((d) => d.name === distro.name);
               if (!distroExists) {
@@ -146,7 +161,9 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
 
               return {
                 distributions: state.distributions.map((d) =>
-                  d.name === distro.name ? { ...d, diskSize } : d
+                  d.name === distro.name
+                    ? { ...d, diskSize, diskSizeLastFetched: fetchedAt }
+                    : d
                 ),
               };
             });

--- a/src/types/distribution.ts
+++ b/src/types/distribution.ts
@@ -6,6 +6,7 @@ export interface Distribution {
   isDefault: boolean;
   location?: string; // Installation path (from Windows Registry)
   diskSize?: number; // Size in bytes
+  diskSizeLastFetched?: number; // Unix ms timestamp of last successful diskSize fetch
   osInfo?: string; // e.g., "Ubuntu 22.04.3 LTS"
   metadata?: DistroMetadata; // Installation source info (if tracked)
 }


### PR DESCRIPTION
## Summary
- Track `diskSizeLastFetched` per distro so cached disk sizes can age out.
- Refetch `diskSize` when it is missing, was hydrated without a timestamp, or is older than `DISK_SIZE_REFRESH_INTERVAL_MS` (5 min).
- Preserves the OCT-314 protection against per-poll WSL spam while keeping displayed disk usage current as the VHDX grows or compacts.

## Why
The OCT-314 fix cached `diskSize` after the first successful fetch and never re-queried it (`!d.diskSize` check), so disk usage went stale until restart.

## Test plan
- [ ] Vitest: `npm test src/store/distroStore.test.ts` (new tests cover fresh-cache skip, stale-cache refetch, missing-timestamp refetch, and timestamp recording)
- [ ] Manual: open app, note disk size, write a large file inside a distro, wait >5 minutes, verify UI updates within one poll cycle.

Closes OCT-445.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>