### PR TITLE
feat(OCT-445): manual refresh button bypasses diskSize cache

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -169,7 +169,7 @@ export function Header({ onOpenSettings }: HeaderProps) {
             size="sm"
             className="btn-cyber"
             icon={<RefreshIcon size="sm" className={isLoading ? "animate-spin" : ""} />}
-            onClick={() => fetchDistros()}
+            onClick={() => fetchDistros(false, true)}
             disabled={isLoading || !!actionInProgress}
             data-testid="refresh-button"
           >

--- a/src/store/distroStore.test.ts
+++ b/src/store/distroStore.test.ts
@@ -926,6 +926,34 @@ describe("distroStore", () => {
       expect(wslService.getDistributionDiskSize).toHaveBeenCalledTimes(3);
     });
 
+    it("refetches diskSize when force=true even if cache is fresh", async () => {
+      vi.mocked(wslService.listDistributions).mockResolvedValue(
+        mockDistributions
+      );
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(
+        1024 * 1024
+      );
+
+      await useDistroStore.getState().fetchDistros();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Cache is fresh — a normal fetch would skip the disk size calls.
+      vi.mocked(wslService.getDistributionDiskSize).mockClear();
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(
+        9 * 1024 * 1024
+      );
+
+      // Force refresh (silent=false, force=true) — should refetch all distros.
+      await useDistroStore.getState().fetchDistros(false, true);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(wslService.getDistributionDiskSize).toHaveBeenCalledTimes(3);
+      const ubuntu = useDistroStore
+        .getState()
+        .distributions.find((d) => d.name === "Ubuntu");
+      expect(ubuntu?.diskSize).toBe(9 * 1024 * 1024);
+    });
+
     it("records diskSizeLastFetched alongside diskSize on successful fetch", async () => {
       vi.mocked(wslService.listDistributions).mockResolvedValue(
         mockDistributions

--- a/src/store/distroStore.ts
+++ b/src/store/distroStore.ts
@@ -24,7 +24,7 @@ interface DistroStore {
   compactingDistro: string | null;
 
   // Actions
-  fetchDistros: (silent?: boolean) => Promise<void>;
+  fetchDistros: (silent?: boolean, force?: boolean) => Promise<void>;
   startDistro: (name: string, id?: string) => Promise<void>;
   stopDistro: (name: string) => Promise<void>;
   deleteDistro: (name: string) => Promise<void>;
@@ -78,7 +78,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
   actionInProgress: null,
   compactingDistro: null,
 
-  fetchDistros: async (silent?: boolean) => {
+  fetchDistros: async (silent?: boolean, force?: boolean) => {
     // Increment fetch ID to invalidate any pending background requests
     const fetchId = ++currentFetchId;
 
@@ -120,8 +120,11 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
       // with commands on every 10-second poll cycle.
       // diskSize is refreshed if older than DISK_SIZE_REFRESH_INTERVAL_MS so
       // the displayed value stays accurate as the VHDX grows or is compacted.
+      // When force=true (manual refresh button), bypass the staleness check
+      // and refetch diskSize for all distros immediately.
       const now = Date.now();
       const distrosMissingDiskSize = distributions.filter((d) => {
+        if (force) return true;
         if (d.diskSize === undefined) return true;
         if (d.diskSizeLastFetched === undefined) return true;
         return now - d.diskSizeLastFetched >= DISK_SIZE_REFRESH_INTERVAL_MS;


### PR DESCRIPTION
## Summary
Follow-up to #94. The 5-minute auto-refresh keeps disk usage current under normal use, but provided no way to force an immediate refresh after explicit user actions (compact, large file copy, etc).

- Added optional `force` parameter to `fetchDistros(silent, force)` — bypasses the `DISK_SIZE_REFRESH_INTERVAL_MS` staleness check when `true`.
- Header sync button now calls `fetchDistros(false, true)` so a click forces a fresh `diskSize` fetch for every distro.
- Polling and all other internal call sites are unchanged — they keep the cached behaviour.

Together with #94 this covers both bullets of the OCT-445 suggested approach (periodic refresh + explicit user action).

## Test plan
- [ ] `npm test src/store/distroStore.test.ts` — new test "refetches diskSize when force=true even if cache is fresh" passes.
- [ ] Manual: open app, note disk size, change something inside a distro, click the Sync button, confirm disk size updates without waiting 5 minutes.

Closes OCT-445.

Co-Authored-By: Paperclip <noreply@paperclip.ing>