### PR TITLE
fix: enforce single app instance so re-launches focus existing tray w…

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1144,6 +1144,40 @@ New-Item -ItemType Directory -Force "$env:LOCALAPPDATA\wsl" | Out-Null
 
 ---
 
+## Issue #16: Re-launching the app spawns a new window while one is already minimised to the tray
+
+### Symptoms
+- User has "Minimize to tray" enabled (or chose "Minimize" from the close-action dialog).
+- Closing the window hides it; tray icon remains as expected.
+- User then re-opens the app from a desktop shortcut, the Start menu, or a pinned taskbar icon (anything other than clicking the tray icon).
+- A *second* window appears, and a *second* tray icon is added next to the first.
+- Closing that new window minimises it too, so the user can end up with multiple "minimised" instances and multiple tray icons.
+
+### Root Cause
+The app did not enforce single-instance behaviour. Each time the `wsl-ui.exe` binary is launched, Windows spawns a new process. Each process independently:
+- creates its own `main` webview window (`visible: true` in `tauri.conf.json`),
+- builds and registers its own system tray icon.
+
+Clicking the tray icon correctly calls `show_main_window` on whichever process owns that icon, but it does not deduplicate processes. Tauri does not enforce single-instance by default — it has to be opted into via `tauri-plugin-single-instance`.
+
+### Diagnosis
+1. Reproduce: enable "Minimize to tray", close the window, then double-click the desktop / Start menu shortcut.
+2. Open Task Manager → Details. You will see multiple `wsl-ui.exe` processes — one per launch.
+3. The notification area shows one tray icon per process.
+
+### Solution
+Added the official `tauri-plugin-single-instance` plugin. When a second `wsl-ui.exe` launches, the secondary process's call to `tauri::Builder::default().plugin(...)` triggers the callback in the primary process and the secondary exits. The callback reuses the existing `show_main_window` helper, which on Windows performs `show()` → `unminimize()` → `set_focus()`, restoring the hidden/minimised primary window instead of creating a new one.
+
+### Files Changed
+- `src-tauri/Cargo.toml`: added `tauri-plugin-single-instance = "2"` dependency.
+- `src-tauri/src/main.rs`: registered the plugin before any other plugin in `tauri::Builder::default()`; callback calls `show_main_window(app)`.
+
+### Related
+- Tauri v2 single-instance docs: https://v2.tauri.app/plugin/single-instance/
+- Paperclip issue: OCT-940
+
+---
+
 ## Template for New Issues
 
 ```markdown

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -125,6 +125,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +207,30 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -236,6 +333,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -2865,6 +2975,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +3015,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4330,6 +4465,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.17",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acba6b5ca527a96cdfcc96ae09b09ccb91ddff5e33978ca6873b96ea16bb404c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.17",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -5841,6 +5991,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "thiserror 2.0.17",
  "tokio",
  "winreg",
@@ -5918,8 +6069,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-plugin-shell = "2.2"
 tauri-plugin-dialog = "2.2"
 tauri-plugin-fs = "2"
 tauri-plugin-log = { version = "2", features = ["colored"] }
+tauri-plugin-single-instance = "2"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -268,6 +268,15 @@ fn main() {
     let log_dir = utils::get_config_dir().join("logs");
 
     tauri::Builder::default()
+        // Enforce a single running instance. When a user re-launches the app
+        // (e.g. via desktop shortcut or Start menu) while it is already running
+        // and hidden in the tray, this callback fires on the primary instance
+        // and brings its existing window back instead of spawning a new one.
+        // Without this, every re-launch creates a new process with its own
+        // tray icon and window — see OCT-940.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            show_main_window(app);
+        }))
         .plugin(
             tauri_plugin_log::Builder::new()
                 .clear_targets()


### PR DESCRIPTION
…indow (OCT-940)

When close action is set to "Minimize to tray", clicking the desktop or Start menu shortcut while the app was already hidden caused Windows to launch a brand new wsl-ui.exe process. Each process built its own window and its own tray icon, so users could end up with multiple "minimised" instances stacked in the notification area.

Add tauri-plugin-single-instance and re-use show_main_window in its callback so subsequent launches simply restore the primary window (show + unminimize + focus) and the secondary process exits.