### PR TITLE
fix(settings): preserve vmIdleTimeout=-1 sentinel on save (OCT-1258)

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -173,7 +173,9 @@ pub struct WslConfig {
     pub localhost_forwarding: Option<bool>,
     pub kernel_command_line: Option<String>,
     pub nested_virtualization: Option<bool>,
-    pub vm_idle_timeout: Option<u32>,
+    // Signed: `-1` is the documented WSL "never idle-shutdown" sentinel
+    // (used by the RDP keep-alive feature), so this must not be unsigned.
+    pub vm_idle_timeout: Option<i64>,
     pub gui_applications: Option<bool>,
     pub debug_console: Option<bool>,
     pub page_reporting: Option<bool>,
@@ -392,9 +394,9 @@ fn parse_wsl_config(content: &str) -> Result<WslConfig, String> {
         nested_virtualization: ini.getbool("wsl2", "nestedVirtualization")
             .ok().flatten()
             .or_else(|| ini.getbool("wsl2", "nestedvirtualization").ok().flatten()),
-        vm_idle_timeout: ini.getuint("wsl2", "vmIdleTimeout").ok().flatten()
-            .or_else(|| ini.getuint("wsl2", "vmidletimeout").ok().flatten())
-            .map(|v| v as u32),
+        // Signed parse so the documented `-1` sentinel survives (getuint drops it).
+        vm_idle_timeout: ini.getint("wsl2", "vmIdleTimeout").ok().flatten()
+            .or_else(|| ini.getint("wsl2", "vmidletimeout").ok().flatten()),
         gui_applications: ini.getbool("wsl2", "guiApplications")
             .ok().flatten()
             .or_else(|| ini.getbool("wsl2", "guiapplications").ok().flatten()),
@@ -765,6 +767,25 @@ firewall=false
         assert_eq!(parsed.dns_tunneling, Some(true));
         assert_eq!(parsed.firewall, Some(false));
         assert_eq!(parsed.networking_mode, Some("mirrored".to_string()));
+    }
+
+    #[test]
+    fn test_wsl_config_vm_idle_timeout_negative_one_roundtrip() {
+        // Regression for OCT-1258 / GH #129: `-1` is the documented WSL
+        // "never idle-shutdown" sentinel and the app's RDP keep-alive relies on
+        // it. It must survive a parse -> serialize round-trip (previously the
+        // Option<u32> field + unsigned parse dropped it silently on save).
+        let content = "[wsl2]\nvmIdleTimeout=-1\n";
+        let config = parse_wsl_config(content).unwrap();
+
+        assert_eq!(config.vm_idle_timeout, Some(-1));
+
+        let serialized = serialize_wsl_config(&config);
+        assert!(
+            serialized.contains("vmIdleTimeout=-1"),
+            "vmIdleTimeout=-1 must be preserved on save, got:\n{}",
+            serialized
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #129

## Problem
Saving WSL global settings silently **deleted** an existing `vmIdleTimeout=-1` line from `.wslconfig`. `-1` is the documented WSL "never idle-shutdown" sentinel, and this app's own **RDP keep-alive** feature recommends and checks for it (`parse_wsl_config_timeouts` in `commands.rs` treats `-1` as a first-class value).

Because `WslConfig.vm_idle_timeout` was `Option<u32>` and parsed with the unsigned `ini.getuint` reader, `-1` couldn't be parsed back → round-tripped to `None` → dropped on the next `write_wsl_config`. Editing *any* unrelated setting reverted the VM to the default 60s idle timeout and dropped idle SSH/RDP sessions. The UI could never display or edit an existing `-1` either.

## Root cause
- `WslConfig.vm_idle_timeout: Option<u32>` (`src-tauri/src/settings.rs:176`)
- Parse via `ini.getuint(...)` — unsigned only → `-1` yields `None` (`settings.rs:395`)
- `serialize_wsl_config` emits nothing when `None`; `write_wsl_config` rewrites the whole file → line lost

## Fix
- Widen `vm_idle_timeout` to `Option<i64>`.
- Parse with the signed `ini.getint` reader so `-1` (and any other value) survives a parse → serialize round-trip. Serialization is unchanged (`{}` formatting already handles `i64`).
- Add a `vmIdleTimeout=-1` round-trip regression test. The pre-existing `test_parse_wsl_config_all_fields` only exercised a positive value (`60000`), which masked the bug.

Distinct from #108 (unmodeled keys — this key *is* modeled) and #126 (wrong INI section — this is the right section, wrong type).

## Verification
Written test-first: added the regression test, watched it fail (serialized output was just `[wsl2]` — the `-1` line dropped), then applied the fix.

- `cargo test settings::tests` — 14 passed (incl. new `test_wsl_config_vm_idle_timeout_negative_one_roundtrip`)
- `cargo test` (full suite) — **309 passed, 0 failed**

The frontend TS type (`vmIdleTimeout?: number`) already represents `-1`, so no client change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)