### PR TITLE
fix: gate VHDX resize/move/sparse on confirmed stop/shutdown (GH #123)

### DIFF
--- a/src/hooks/useStopBeforeAction.test.ts
+++ b/src/hooks/useStopBeforeAction.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useStopBeforeAction } from "./useStopBeforeAction";
+import { useDistroStore } from "../store/distroStore";
+import { useNotificationStore } from "../store/notificationStore";
+import type { Distribution } from "../types/distribution";
+
+const makeDistro = (overrides: Partial<Distribution> = {}): Distribution =>
+  ({
+    id: "{guid}",
+    name: "Ubuntu",
+    state: "Running",
+    isDefault: true,
+    wslVersion: 2,
+    ...overrides,
+  }) as Distribution;
+
+/**
+ * Populate the pending action by running executeWithStopCheck against a
+ * running distro (which opens the dialog), then invoke handleStopAndContinue.
+ */
+async function runStopAndContinue(
+  pendingAction: () => void,
+  options?: { requiresShutdown?: boolean }
+) {
+  const { result } = renderHook(() => useStopBeforeAction());
+
+  act(() => {
+    result.current.executeWithStopCheck(
+      makeDistro(),
+      "Resize",
+      pendingAction,
+      options
+    );
+  });
+
+  await act(async () => {
+    await result.current.handleStopAndContinue();
+  });
+}
+
+describe("useStopBeforeAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useNotificationStore.setState({ notifications: [] });
+    useDistroStore.setState({
+      distributions: [makeDistro()],
+      error: null,
+    });
+  });
+
+  it("runs the pending action when stop succeeds and nothing is running", async () => {
+    const pendingAction = vi.fn();
+    useDistroStore.setState({
+      stopDistro: vi.fn().mockResolvedValue(true),
+      shutdownAll: vi.fn().mockResolvedValue(true),
+      // Simulate the re-fetch observing the distro is now stopped.
+      fetchDistros: vi.fn().mockImplementation(async () => {
+        useDistroStore.setState({
+          distributions: [makeDistro({ state: "Stopped" })],
+        });
+      }),
+    });
+
+    await runStopAndContinue(pendingAction);
+
+    expect(pendingAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT run the destructive action when stopDistro fails", async () => {
+    const pendingAction = vi.fn();
+    useDistroStore.setState({
+      // Store swallows the error and reports failure via the boolean.
+      stopDistro: vi.fn().mockResolvedValue(false),
+      shutdownAll: vi.fn().mockResolvedValue(false),
+      // Distro is still running because the stop failed.
+      fetchDistros: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await runStopAndContinue(pendingAction);
+
+    expect(pendingAction).not.toHaveBeenCalled();
+  });
+
+  it("does NOT run the destructive action when shutdownAll fails (requiresShutdown)", async () => {
+    const pendingAction = vi.fn();
+    useDistroStore.setState({
+      stopDistro: vi.fn().mockResolvedValue(false),
+      shutdownAll: vi.fn().mockResolvedValue(false),
+      fetchDistros: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await runStopAndContinue(pendingAction, { requiresShutdown: true });
+
+    expect(pendingAction).not.toHaveBeenCalled();
+  });
+
+  it("aborts and notifies when the stop reports success but WSL is still running", async () => {
+    const pendingAction = vi.fn();
+    useDistroStore.setState({
+      stopDistro: vi.fn().mockResolvedValue(true),
+      shutdownAll: vi.fn().mockResolvedValue(true),
+      // Re-fetch still shows a running distro: VHDX is still locked.
+      fetchDistros: vi.fn().mockImplementation(async () => {
+        useDistroStore.setState({
+          distributions: [makeDistro({ state: "Running" })],
+        });
+      }),
+    });
+
+    await runStopAndContinue(pendingAction, { requiresShutdown: true });
+
+    expect(pendingAction).not.toHaveBeenCalled();
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    expect(useNotificationStore.getState().notifications[0].type).toBe("error");
+  });
+});

--- a/src/hooks/useStopBeforeAction.ts
+++ b/src/hooks/useStopBeforeAction.ts
@@ -12,6 +12,7 @@
 import { useState, useCallback } from "react";
 import type { Distribution } from "../types/distribution";
 import { useDistroStore } from "../store/distroStore";
+import { useNotificationStore } from "../store/notificationStore";
 
 interface StopBeforeActionState {
   /** Whether the stop dialog is currently shown */
@@ -124,26 +125,55 @@ export function useStopBeforeAction(): UseStopBeforeActionReturn {
    * Either stops the distribution or shuts down all WSL, then executes the pending action.
    */
   const handleStopAndContinue = useCallback(async () => {
-    const { distro, pendingAction, requiresShutdown } = state;
+    const { distro, pendingAction, requiresShutdown, actionName } = state;
 
     if (!distro || !pendingAction) {
       setState(initialState);
       return;
     }
 
-    // Either shutdown all WSL or just stop the specific distribution
-    if (requiresShutdown) {
-      await shutdownAll();
-    } else {
-      await stopDistro(distro.name);
-    }
+    // Either shutdown all WSL or just stop the specific distribution.
+    // These now report success: they resolve to false (and set the store's
+    // error state) when the stop/shutdown fails, instead of silently
+    // swallowing the error. We must NOT run the destructive VHDX operation
+    // against a VM that is still running (its VHDX would still be locked).
+    const stopped = requiresShutdown
+      ? await shutdownAll()
+      : await stopDistro(distro.name);
 
-    // Wait for state to update
+    // Re-fetch so we can confirm the VM is actually stopped before proceeding.
     await fetchDistros();
 
-    // Close dialog and execute the pending action
+    // Double-check nothing is still running. A stop can report success while
+    // WSL is slow to release the VHDX lock, so verify against fresh store
+    // state (not the possibly-stale render closure).
+    const latest = useDistroStore.getState().distributions;
+    const stillRunning = requiresShutdown
+      ? latest.some((d) => d.state === "Running")
+      : latest.find((d) => d.name === distro.name)?.state === "Running";
+
+    // Always close the dialog.
     setState(initialState);
-    pendingAction();
+
+    if (stopped && !stillRunning) {
+      // Safe to proceed: the VHDX is no longer locked.
+      pendingAction();
+      return;
+    }
+
+    // Abort the destructive action. If the stop itself failed, the store
+    // already set an error message. If it reported success but something is
+    // still running, surface an explicit notification so this isn't a silent
+    // no-op that leaves the user wondering why nothing happened.
+    if (stopped && stillRunning) {
+      useNotificationStore.getState().addNotification({
+        type: "error",
+        title: `Cannot ${actionName}`,
+        message: `WSL is still running after the ${
+          requiresShutdown ? "shutdown" : "stop"
+        } request, so ${distro.name}'s disk is still in use. Please shut WSL down manually and try again.`,
+      });
+    }
   }, [state, stopDistro, shutdownAll, fetchDistros]);
 
   /**

--- a/src/store/distroStore.test.ts
+++ b/src/store/distroStore.test.ts
@@ -439,6 +439,26 @@ describe("distroStore", () => {
       expect(useDistroStore.getState().actionInProgress).toBeNull();
     });
 
+    it("returns true on success", async () => {
+      vi.mocked(wslService.stopDistribution).mockResolvedValue(undefined);
+      vi.mocked(wslService.listDistributions).mockResolvedValue([]);
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(0);
+
+      const result = await useDistroStore.getState().stopDistro("Ubuntu");
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false on failure (does not swallow the error silently)", async () => {
+      vi.mocked(wslService.stopDistribution).mockRejectedValue(
+        new Error("Stop failed")
+      );
+
+      const result = await useDistroStore.getState().stopDistro("Ubuntu");
+
+      expect(result).toBe(false);
+    });
+
     it("sets isTimeoutError true for timeout errors", async () => {
       vi.mocked(wslService.stopDistribution).mockRejectedValue(
         new Error("Operation timed out")
@@ -511,6 +531,27 @@ describe("distroStore", () => {
       );
 
       await shutdownPromise;
+    });
+
+    it("returns true on success", async () => {
+      vi.mocked(wslService.shutdownAll).mockResolvedValue(undefined);
+      vi.mocked(wslService.listDistributions).mockResolvedValue([]);
+      vi.mocked(wslService.getDistributionDiskSize).mockResolvedValue(0);
+
+      const result = await useDistroStore.getState().shutdownAll();
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false on failure (does not swallow the error silently)", async () => {
+      vi.mocked(wslService.shutdownAll).mockRejectedValue(
+        new Error("Shutdown failed")
+      );
+
+      const result = await useDistroStore.getState().shutdownAll();
+
+      expect(result).toBe(false);
+      expect(useDistroStore.getState().error).toBe("Shutdown failed");
     });
   });
 

--- a/src/store/distroStore.ts
+++ b/src/store/distroStore.ts
@@ -26,9 +26,11 @@ interface DistroStore {
   // Actions
   fetchDistros: (silent?: boolean, force?: boolean) => Promise<void>;
   startDistro: (name: string, id?: string) => Promise<void>;
-  stopDistro: (name: string) => Promise<void>;
+  /** Stop a distro. Resolves true on success, false if the stop failed (error is set on the store). */
+  stopDistro: (name: string) => Promise<boolean>;
   deleteDistro: (name: string) => Promise<void>;
-  shutdownAll: () => Promise<void>;
+  /** Shut down all WSL. Resolves true on success, false if the shutdown failed (error is set on the store). */
+  shutdownAll: () => Promise<boolean>;
   forceKillWsl: () => Promise<void>;
   setDefault: (name: string) => Promise<void>;
   openTerminal: (name: string, id?: string) => Promise<void>;
@@ -299,6 +301,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
     try {
       await wslService.stopDistribution(name);
       await get().fetchDistros();
+      return true;
     } catch (error) {
       const appError = parseError(error);
       logError(appError, "distroStore.stopDistro");
@@ -307,6 +310,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
         error: errorMessage,
         isTimeoutError: isTimeoutErrorMessage(errorMessage),
       });
+      return false;
     } finally {
       set({ actionInProgress: null });
     }
@@ -332,6 +336,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
     try {
       await wslService.shutdownAll();
       await get().fetchDistros();
+      return true;
     } catch (error) {
       const appError = parseError(error);
       logError(appError, "distroStore.shutdownAll");
@@ -340,6 +345,7 @@ export const useDistroStore = create<DistroStore>((set, get) => ({
         error: errorMessage,
         isTimeoutError: isTimeoutErrorMessage(errorMessage),
       });
+      return false;
     } finally {
       set({ actionInProgress: null });
     }


### PR DESCRIPTION
Fixes #123.

## Problem

A VHDX-locking operation (Resize / Move / toggle Sparse) gated behind the **Stop & Continue** / **Shutdown & Continue** dialog proceeded even when the stop/shutdown **silently failed**, running the destructive op against a still-running VM whose VHDX was still locked.

## Root cause

`useStopBeforeAction.handleStopAndContinue` awaited `shutdownAll()`/`stopDistro()` then **unconditionally** called `pendingAction()`. Both store actions caught errors and set `error` state but never re-threw or reported failure, so the `await` always resolved successfully — the stop failure was invisible to the caller.

Reachability: QuickActionsMenu → Manage → Resize/Move/Sparse → `executeWithStopCheck(…, {requiresShutdown:true})` → "Shutdown & Continue" → stop fails silently → destructive dialog opens against the live VM.

## Fix

- `stopDistro` / `shutdownAll` now resolve to a `boolean` (`true` on success, `false` on caught failure) instead of `Promise<void>`. Error state is still set as before.
- `handleStopAndContinue` only runs the pending destructive action when the stop **succeeded** *and* a re-fetch confirms **nothing is still running**. Otherwise it aborts:
  - stop failed → the store's error state already surfaces the failure;
  - stop reported success but a distro is still running (WSL slow to release the VHDX lock) → an explicit error notification is shown instead of a silent no-op.

Existing callers (`Header`, `DistroCard`) ignore the return value, so the signature change is backward compatible.

## Tests

- `src/hooks/useStopBeforeAction.test.ts` (new): happy path runs the action; aborts when `stopDistro`/`shutdownAll` fail; aborts + notifies when stop reports success but WSL is still running.
- `src/store/distroStore.test.ts`: boolean return contract for `stopDistro`/`shutdownAll` (true on success, false on failure).

`tsc --noEmit` clean. New tests green.

Note: a pre-existing flaky test (`fetchDistros > component unmount` stale-request timing) is unrelated to this change — it fails intermittently on `main` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)