### PR TITLE
fix(security): sanitize wsl.conf field values before root heredoc write (OCT-1159, GH #111)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1320,6 +1320,10 @@ pub async fn get_wsl_conf_raw(distro_name: String, id: Option<String>) -> Result
 #[tauri::command]
 pub async fn save_wsl_conf(distro_name: String, config: WslConf) -> Result<(), String> {
     validate_distro_name(&distro_name).map_err(|e| e.to_string())?;
+    // Reject field values that could inject INI lines or escape the root heredoc used to
+    // write /etc/wsl.conf (newlines / control chars). Fails fast before spawning the
+    // blocking write; write_wsl_conf re-validates as a defense-in-depth chokepoint.
+    settings::validate_wsl_conf(&config).map_err(|e| e.to_string())?;
     tokio::task::spawn_blocking(move || settings::write_wsl_conf(&distro_name, config))
         .await
         .map_err(|e| format!("Task failed: {}", e))?

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -588,6 +588,11 @@ fn parse_wsl_conf(content: &str) -> Result<WslConf, String> {
 /// Write wsl.conf to a distribution
 /// Uses wsl -u root to write with root privileges since /etc/wsl.conf is typically owned by root
 pub fn write_wsl_conf(distro_name: &str, config: WslConf) -> Result<(), String> {
+    // Reject any value that could escape the root heredoc below (embedded newlines /
+    // control chars). This is the single chokepoint every wsl.conf write flows through,
+    // so validating here protects all callers regardless of the Tauri boundary check.
+    validate_wsl_conf(&config).map_err(|e| e.to_string())?;
+
     if is_mock_mode() {
         return Ok(());
     }
@@ -610,6 +615,33 @@ pub fn write_wsl_conf(distro_name: &str, config: WslConf) -> Result<(), String> 
             "Failed to write wsl.conf: {}",
             output.stderr.trim()
         ));
+    }
+
+    Ok(())
+}
+
+/// Validate every user-supplied string value in a [`WslConf`] before it is written.
+///
+/// `write_wsl_conf` serializes these values into an INI file that is written to the
+/// distro as **root** via a shell heredoc. Any embedded newline can inject extra INI
+/// lines/sections, and a line equal to the heredoc delimiter can escape the heredoc and
+/// run trailing lines as root. Rejecting control characters in each value closes both
+/// vectors. See [`crate::validation::validate_wsl_conf_value`].
+pub fn validate_wsl_conf(config: &WslConf) -> Result<(), crate::validation::ValidationError> {
+    use crate::validation::validate_wsl_conf_value;
+
+    let string_fields: [(&str, &Option<String>); 5] = [
+        ("automount.root", &config.automount_root),
+        ("automount.options", &config.automount_options),
+        ("network.hostname", &config.network_hostname),
+        ("user.default", &config.user_default),
+        ("boot.command", &config.boot_command),
+    ];
+
+    for (field, value) in string_fields {
+        if let Some(value) = value {
+            validate_wsl_conf_value(field, value)?;
+        }
     }
 
     Ok(())
@@ -938,6 +970,73 @@ command=/etc/init.d/start.sh
         assert!(serialized.contains("root=/mnt/"));
         assert!(serialized.contains("[boot]"));
         assert!(serialized.contains("systemd=true"));
+    }
+
+    // ==================== wsl.conf Injection Validation Tests ====================
+
+    #[test]
+    fn test_validate_wsl_conf_accepts_clean_config() {
+        let config = WslConf {
+            automount_root: Some("/mnt/".to_string()),
+            automount_options: Some("metadata,uid=1000".to_string()),
+            network_hostname: Some("my-host".to_string()),
+            user_default: Some("ian".to_string()),
+            boot_command: Some("service docker start; echo ready".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_wsl_conf(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_wsl_conf_default_is_ok() {
+        assert!(validate_wsl_conf(&WslConf::default()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_wsl_conf_rejects_newline_in_boot_command() {
+        // The classic root-command-execution carrier: a newline lets the value break out
+        // of the heredoc / inject a new INI line.
+        let config = WslConf {
+            boot_command: Some("echo hi\nWSLCONFEOF\ntouch /tmp/pwned".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_wsl_conf(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_wsl_conf_rejects_newline_in_hostname() {
+        let config = WslConf {
+            network_hostname: Some("host\n[boot]\ncommand=malicious".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_wsl_conf(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_wsl_conf_rejects_newline_in_automount_options() {
+        let config = WslConf {
+            automount_options: Some("metadata\nuid=0".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_wsl_conf(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_wsl_conf_rejects_newline_in_automount_root() {
+        let config = WslConf {
+            automount_root: Some("/mnt/\ninjected".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_wsl_conf(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_wsl_conf_rejects_newline_in_user_default() {
+        let config = WslConf {
+            user_default: Some("root\ninjected".to_string()),
+            ..Default::default()
+        };
+        assert!(validate_wsl_conf(&config).is_err());
     }
 
     // ==================== Round-trip Tests ====================

--- a/src-tauri/src/validation.rs
+++ b/src-tauri/src/validation.rs
@@ -22,6 +22,9 @@ pub enum ValidationError {
 
     #[error("Invalid action ID: {0}")]
     InvalidActionId(String),
+
+    #[error("Invalid value for {field}: {reason}")]
+    InvalidConfigValue { field: String, reason: String },
 }
 
 /// Validate WSL distribution name
@@ -300,6 +303,33 @@ pub fn validate_action_id(id: &str) -> Result<(), ValidationError> {
         return Err(ValidationError::InvalidActionId(
             "ID can only contain letters, numbers, hyphens, and underscores".into(),
         ));
+    }
+
+    Ok(())
+}
+
+/// Validate a single user-supplied `wsl.conf` INI value.
+///
+/// `wsl.conf` values are serialized into an INI file that is written to the distro as
+/// **root** via a shell heredoc (`cat > /etc/wsl.conf << 'WSLCONFEOF'`). A value that
+/// contains a newline can inject arbitrary extra INI lines/sections, and a value whose
+/// line equals the heredoc delimiter terminates the heredoc early — after which the
+/// trailing lines execute as root shell commands. Rejecting all control characters
+/// (which include `\n`, `\r`, and `\0`) closes both vectors: without a newline a value
+/// cannot start a new INI line, break out of the heredoc, or reach the delimiter line.
+///
+/// Every `wsl.conf` value is a single INI line, so no legitimate value needs a control
+/// character. This is intentionally strict for `boot.command` too — the command itself
+/// is a single line and may contain spaces, `;`, `|`, `$`, etc., but never a newline.
+pub fn validate_wsl_conf_value(field: &str, value: &str) -> Result<(), ValidationError> {
+    if let Some(c) = value.chars().find(|c| c.is_control()) {
+        return Err(ValidationError::InvalidConfigValue {
+            field: field.to_string(),
+            reason: format!(
+                "value cannot contain control characters (found U+{:04X})",
+                c as u32
+            ),
+        });
     }
 
     Ok(())
@@ -738,5 +768,73 @@ mod tests {
         assert!(validate_url("file:///etc/passwd").is_err());
         assert!(validate_url("/local/path").is_err());
         assert!(validate_url("example.com/file").is_err());
+    }
+
+    // ==================== wsl.conf Value Tests ====================
+
+    #[test]
+    fn test_valid_wsl_conf_values() {
+        // Legitimate single-line values across the string fields.
+        assert!(validate_wsl_conf_value("automount.root", "/mnt/").is_ok());
+        assert!(validate_wsl_conf_value("automount.options", "metadata,uid=1000,gid=1000,umask=22").is_ok());
+        assert!(validate_wsl_conf_value("network.hostname", "my-host").is_ok());
+        assert!(validate_wsl_conf_value("user.default", "ian").is_ok());
+        // boot.command is a shell command line — spaces and shell metacharacters are fine,
+        // as long as it stays on one line.
+        assert!(validate_wsl_conf_value("boot.command", "service docker start; echo ready | tee /tmp/x").is_ok());
+        // Empty value is allowed.
+        assert!(validate_wsl_conf_value("user.default", "").is_ok());
+    }
+
+    #[test]
+    fn test_wsl_conf_value_rejects_newline() {
+        // A newline lets a value inject arbitrary extra INI lines/sections.
+        let result = validate_wsl_conf_value("boot.command", "echo hi\n[boot]\ncommand=malicious");
+        assert!(matches!(
+            result,
+            Err(ValidationError::InvalidConfigValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_wsl_conf_value_rejects_carriage_return() {
+        let result = validate_wsl_conf_value("network.hostname", "host\rinjected");
+        assert!(matches!(
+            result,
+            Err(ValidationError::InvalidConfigValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_wsl_conf_value_rejects_heredoc_delimiter_escape() {
+        // A value carrying the heredoc delimiter on its own line would terminate the
+        // heredoc early and run the trailing lines as root. The embedded newline is
+        // what makes this possible, so it must be rejected.
+        let result = validate_wsl_conf_value(
+            "boot.command",
+            "echo hi\nWSLCONFEOF\ntouch /tmp/pwned",
+        );
+        assert!(matches!(
+            result,
+            Err(ValidationError::InvalidConfigValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_wsl_conf_value_rejects_null_byte() {
+        let result = validate_wsl_conf_value("user.default", "root\0");
+        assert!(matches!(
+            result,
+            Err(ValidationError::InvalidConfigValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_wsl_conf_value_rejects_control_char() {
+        let result = validate_wsl_conf_value("automount.options", "metadata\x07uid=0");
+        assert!(matches!(
+            result,
+            Err(ValidationError::InvalidConfigValue { .. })
+        ));
     }
 }


### PR DESCRIPTION
## Summary
Fixes a **security-critical** value-injection bug: saving `/etc/wsl.conf` from Settings interpolated user-supplied `WslConf` string values **raw** into a heredoc executed **as root** in the distro (`cat > /etc/wsl.conf << 'WSLCONFEOF'` via `exec_as_root`), with no validation.

- **Config corruption:** a string field containing a newline injects arbitrary extra INI lines/sections.
- **Root command execution:** a value containing a `WSLCONFEOF` delimiter line terminates the heredoc early; the trailing lines then run as **root** shell commands.

Resolves OCT-1159 / GH #111. Distinct from GH #105 (automount options quote doubling) and GH #108 (dropping unmodeled keys) — those are round-trip fidelity; this is value injection / missing sanitization.

## Fix
Reject **control characters** (newlines, CR, NUL, etc.) in every `wsl.conf` string field. Every `wsl.conf` value is a single INI line, so no legitimate value needs a control character. Without an embedded newline a value cannot start a new INI line, escape the heredoc, or reach the delimiter line — closing **both** vectors. `boot.command` may still contain spaces and shell metacharacters (`;`, `|`, `$`, …); it just cannot span multiple lines.

- `validation::validate_wsl_conf_value` — per-value control-character check (new `ValidationError::InvalidConfigValue`).
- `settings::validate_wsl_conf` — aggregate check over all 5 string fields (`automount.root`, `automount.options`, `network.hostname`, `user.default`, `boot.command`).
- Enforced at the `save_wsl_conf` Tauri boundary (fail fast, before spawning the blocking write) **and** re-checked inside `write_wsl_conf` (defense-in-depth chokepoint that protects every caller).

## Tests (TDD)
Added unit tests, each watched fail before implementing:
- `validation`: rejects newline / CR / NUL / other control chars / heredoc-delimiter-escape; accepts legitimate single-line values including a realistic `boot.command`.
- `settings`: `validate_wsl_conf` rejects newline injection in each of the 5 string fields; accepts a clean config and `WslConf::default()`.

Full suite green: **321 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
