### PR TITLE
fix(oci): verify SHA-256 digest + size of layer blobs before import (OCT-1144, GH #106)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1178,6 +1178,45 @@ Added the official `tauri-plugin-single-instance` plugin. When a second `wsl-ui.
 
 ---
 
+## Issue #17: Pulling a container image fails with "Blob digest mismatch" or "Blob size mismatch"
+
+### Symptoms
+- Creating a distro from an OCI/container image (`docker.io`, `ghcr.io`, a custom registry, etc.) fails part-way through with an error such as:
+  - `Registry error: Blob digest mismatch for sha256:...: computed sha256:...`
+  - `Registry error: Blob size mismatch for sha256:...: expected N bytes, got M bytes`
+  - `Registry error: Unsupported digest algorithm '...': only sha256 is supported`
+- The import stops and no distribution is created.
+
+### Root Cause
+Each OCI layer is content-addressable: the manifest declares an exact `sha256` digest and byte size for every layer. WSL-UI now verifies the bytes it downloads against those values before merging layers and handing them to `wsl --import`. An error means the layer that arrived on disk did **not** match what the manifest promised. Common causes:
+- A **truncated or corrupted download** (dropped connection, flaky network, a proxy that mangled the stream) — usually a size mismatch.
+- A registry served over insecure **`http://`** where a MITM or a poisoned cache substituted layer content — a digest mismatch.
+- A registry/mirror bug returning the wrong blob for a digest.
+- A digest that isn't SHA-256 (unsupported): the app rejects it rather than importing unverified bytes.
+
+This is a safety feature: importing an unverified layer could silently produce a broken distro or run tampered content as a "real" distribution.
+
+### Diagnosis
+- Retry the pull. If a **size mismatch** disappears on retry, it was a transient/corrupt download.
+- If a **digest mismatch** persists — especially against an `http://` registry — treat the source as untrusted. Pull the same image over `https://` from the authoritative registry.
+- Verify the image reference is correct and the registry/mirror is healthy.
+
+### Solution
+- Retry over a stable network; transient truncations resolve on a clean re-download (the partial file is deleted automatically, so nothing broken is left behind).
+- Prefer `https://` registries so content can't be tampered with in transit.
+- If the mismatch is reproducible from a trusted `https://` source, the image or registry itself is serving corrupt data — report it upstream.
+
+### Files Changed
+- `src-tauri/src/oci/registry.rs`: `download_blob` streams the layer through a SHA-256 hasher, verifies the computed digest and byte count against the manifest, deletes the partial file and errors on mismatch; added `verify_digest` helper and manifest-digest verification in `get_manifest`.
+- `src-tauri/src/oci/image.rs`: passes the manifest layer `size` into `download_blob`.
+
+### Related
+- GitHub issue: https://github.com/octasoft-ltd/wsl-ui/issues/106
+- Paperclip issue: OCT-1144
+- OCI content-addressable storage / digest spec
+
+---
+
 ## Template for New Issues
 
 ```markdown

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "wsl-core"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "serde",
  "thiserror 2.0.17",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "wsl-ui"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "configparser",

--- a/src-tauri/src/oci/image.rs
+++ b/src-tauri/src/oci/image.rs
@@ -57,8 +57,8 @@ pub fn pull_and_create_rootfs(
             );
         }
 
-        // Download without per-byte progress (progress reported at layer level)
-        client.download_blob(&image, &layer.digest, &layer_path, None)?;
+        // Download with SHA-256 digest + size verification (progress reported at layer level)
+        client.download_blob(&image, &layer.digest, layer.size, &layer_path, None)?;
         downloaded_total += layer.size;
 
         layer_paths.push(layer_path);

--- a/src-tauri/src/oci/registry.rs
+++ b/src-tauri/src/oci/registry.rs
@@ -4,6 +4,7 @@
 
 use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, WWW_AUTHENTICATE};
+use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::path::Path;
 
@@ -160,6 +161,14 @@ impl RegistryClient {
         let body = response.text()
             .map_err(|e| OciError::NetworkError(e.to_string()))?;
 
+        // When the manifest was requested by digest (pinned reference or the
+        // amd64 child of a manifest list), verify the returned bytes match it.
+        // A poisoned manifest would otherwise dictate which layers we pull.
+        if let Some(ref requested_digest) = image.digest {
+            let actual_hex = format!("{:x}", Sha256::digest(body.as_bytes()));
+            verify_digest(requested_digest, &actual_hex)?;
+        }
+
         // Check if it's a manifest list (multi-arch)
         if content_type.contains("manifest.list") || content_type.contains("image.index") {
             let list: ManifestList = serde_json::from_str(&body)
@@ -190,10 +199,17 @@ impl RegistryClient {
     }
 
     /// Download a blob (layer) to a file
+    ///
+    /// The streamed bytes are verified against the content-addressable `digest`
+    /// (`sha256:<hex>`) and, when `expected_size` is non-zero, against the size
+    /// declared in the manifest. On any mismatch the partial file is deleted and
+    /// an error is returned so the import fails loudly rather than silently
+    /// producing a broken distro from a truncated or tampered layer.
     pub fn download_blob(
         &self,
         image: &ImageReference,
         digest: &str,
+        expected_size: u64,
         output_path: &Path,
         progress: Option<&ProgressCallback>,
     ) -> Result<(), OciError> {
@@ -221,6 +237,9 @@ impl RegistryClient {
         let mut file = std::fs::File::create(output_path)?;
         let mut reader = response;
 
+        // Hash the bytes as they stream so we never buffer the whole layer.
+        let mut hasher = Sha256::new();
+
         let mut buffer = [0u8; 8192];
         loop {
             let bytes_read = std::io::Read::read(&mut reader, &mut buffer)
@@ -231,6 +250,7 @@ impl RegistryClient {
             }
 
             file.write_all(&buffer[..bytes_read])?;
+            hasher.update(&buffer[..bytes_read]);
             downloaded += bytes_read as u64;
 
             if let Some(ref cb) = progress {
@@ -238,8 +258,59 @@ impl RegistryClient {
             }
         }
 
+        file.flush()?;
+
+        // Verify declared size first (cheap; catches truncation early).
+        if expected_size != 0 && downloaded != expected_size {
+            let _ = std::fs::remove_file(output_path);
+            return Err(OciError::RegistryError(format!(
+                "Blob size mismatch for {}: expected {} bytes, got {} bytes",
+                digest, expected_size, downloaded
+            )));
+        }
+
+        // Verify content-addressable digest.
+        let actual_hex = format!("{:x}", hasher.finalize());
+        if let Err(e) = verify_digest(digest, &actual_hex) {
+            let _ = std::fs::remove_file(output_path);
+            return Err(e);
+        }
+
         Ok(())
     }
+}
+
+/// Verify that a computed SHA-256 hex string matches an OCI digest reference.
+///
+/// `expected` must be of the form `sha256:<hex>`. Only SHA-256 is supported;
+/// any other algorithm is rejected rather than silently accepted, so a
+/// tampered or malformed digest can never bypass verification.
+fn verify_digest(expected: &str, actual_sha256_hex: &str) -> Result<(), OciError> {
+    let expected = expected.trim();
+    let hex = match expected.split_once(':') {
+        Some(("sha256", hex)) => hex,
+        Some((algo, _)) => {
+            return Err(OciError::RegistryError(format!(
+                "Unsupported digest algorithm '{}': only sha256 is supported",
+                algo
+            )));
+        }
+        None => {
+            return Err(OciError::RegistryError(format!(
+                "Malformed digest '{}': expected 'sha256:<hex>'",
+                expected
+            )));
+        }
+    };
+
+    if !actual_sha256_hex.eq_ignore_ascii_case(hex) {
+        return Err(OciError::RegistryError(format!(
+            "Digest mismatch: expected sha256:{}, computed sha256:{}",
+            hex, actual_sha256_hex
+        )));
+    }
+
+    Ok(())
 }
 
 /// Parse WWW-Authenticate Bearer header into parameters (extracted for testing)
@@ -400,5 +471,153 @@ mod tests {
         assert_eq!(client.registry_url("docker.io"), "https://registry-1.docker.io");
         assert_eq!(client.registry_url("ghcr.io"), "https://ghcr.io");
         assert_eq!(client.registry_url("http://localhost:5000"), "http://localhost:5000");
+    }
+
+    // Tests for verify_digest (content-integrity verification).
+    // `Sha256`/`Digest` are already in scope via `use super::*`.
+    fn sha256_hex(data: &[u8]) -> String {
+        format!("{:x}", Sha256::digest(data))
+    }
+
+    #[test]
+    fn test_verify_digest_matches() {
+        let hex = sha256_hex(b"payload");
+        assert!(verify_digest(&format!("sha256:{}", hex), &hex).is_ok());
+    }
+
+    #[test]
+    fn test_verify_digest_case_insensitive() {
+        let hex = sha256_hex(b"payload");
+        // Registry may present the digest in upper case
+        assert!(verify_digest(&format!("sha256:{}", hex.to_uppercase()), &hex).is_ok());
+    }
+
+    #[test]
+    fn test_verify_digest_mismatch() {
+        let hex = sha256_hex(b"honest bytes");
+        assert!(verify_digest("sha256:0000000000000000000000000000000000000000000000000000000000000000", &hex).is_err());
+    }
+
+    #[test]
+    fn test_verify_digest_rejects_unsupported_algorithm() {
+        // A non-sha256 algorithm must be rejected, never silently accepted
+        let hex = sha256_hex(b"payload");
+        assert!(verify_digest(&format!("sha512:{}", hex), &hex).is_err());
+    }
+
+    #[test]
+    fn test_verify_digest_rejects_malformed() {
+        let hex = sha256_hex(b"payload");
+        assert!(verify_digest("not-a-digest", &hex).is_err());
+    }
+
+    // Integration tests for download_blob content verification.
+    //
+    // download_blob uses a blocking reqwest client, so it must run off the tokio
+    // worker thread (spawn_blocking) while wiremock serves the mock registry.
+    fn mock_image(registry_uri: String) -> ImageReference {
+        ImageReference {
+            registry: registry_uri, // includes the http:// scheme from wiremock
+            repository: "library/test".to_string(),
+            tag: "latest".to_string(),
+            digest: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_download_blob_accepts_matching_digest() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let body = b"a genuine oci layer".to_vec();
+        let digest = format!("sha256:{}", sha256_hex(&body));
+        let size = body.len() as u64;
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let uri = server.uri();
+        let out = std::env::temp_dir().join(format!("oci-blob-ok-{}.bin", std::process::id()));
+        let out_thread = out.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let client = RegistryClient::new();
+            let image = mock_image(uri);
+            client.download_blob(&image, &digest, size, &out_thread, None)
+        })
+        .await
+        .unwrap();
+
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+        assert_eq!(std::fs::read(&out).unwrap(), body);
+        let _ = std::fs::remove_file(&out);
+    }
+
+    #[tokio::test]
+    async fn test_download_blob_rejects_digest_mismatch() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Registry serves tampered bytes but the manifest promised a different digest.
+        let served = b"tampered / MITM'd layer bytes".to_vec();
+        let expected_digest = format!("sha256:{}", sha256_hex(b"the honest layer the manifest points at"));
+        let size = served.len() as u64; // size matches so the digest check is what fires
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(served))
+            .mount(&server)
+            .await;
+
+        let uri = server.uri();
+        let out = std::env::temp_dir().join(format!("oci-blob-digest-mismatch-{}.bin", std::process::id()));
+        let out_thread = out.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let client = RegistryClient::new();
+            let image = mock_image(uri);
+            client.download_blob(&image, &expected_digest, size, &out_thread, None)
+        })
+        .await
+        .unwrap();
+
+        assert!(result.is_err(), "digest mismatch must be rejected");
+        // Partial/tampered file must be deleted so a broken layer is never imported
+        assert!(!out.exists(), "partial file should be removed on digest mismatch");
+    }
+
+    #[tokio::test]
+    async fn test_download_blob_rejects_size_mismatch() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Truncated download: bytes hash fine but fall short of the declared size.
+        let body = b"short layer".to_vec();
+        let digest = format!("sha256:{}", sha256_hex(&body));
+        let declared_size = body.len() as u64 + 100; // manifest promised more bytes
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let uri = server.uri();
+        let out = std::env::temp_dir().join(format!("oci-blob-size-mismatch-{}.bin", std::process::id()));
+        let out_thread = out.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let client = RegistryClient::new();
+            let image = mock_image(uri);
+            client.download_blob(&image, &digest, declared_size, &out_thread, None)
+        })
+        .await
+        .unwrap();
+
+        assert!(result.is_err(), "size mismatch must be rejected");
+        assert!(!out.exists(), "partial file should be removed on size mismatch");
     }
 }


### PR DESCRIPTION
## Problem
`RegistryClient::download_blob` streamed each OCI layer to disk and returned `Ok` **without verifying the bytes** — the `digest` argument was only used to build the URL. There was no SHA-256 check and no size check against the manifest layer `size`.

Impact:
- **Truncated/corrupted downloads** silently produced broken distros with no diagnostic.
- The app supports insecure **`http://`** registries, so a **MITM / cache-poisoned layer** was accepted and imported as a real WSL distro — defeating OCI content-addressable integrity.

## Fix
- Hash each blob through `Sha256` **while streaming** (no full-layer buffering).
- Verify the computed digest against `sha256:<hex>`; reject non-`sha256` algorithms rather than silently accepting them.
- Verify the downloaded byte count against the manifest layer `size`.
- On **any** mismatch: delete the partial file and return an error so `wsl --import` never receives corrupt content — import fails loudly.
- Also verify manifest bytes in `get_manifest` when fetched by digest (pinned reference and the amd64 child of a manifest list).
- Caller in `oci/image.rs` now passes the manifest layer `size` into `download_blob`.

## Tests
Added to `src-tauri/src/oci/registry.rs` (all green, `cargo test oci::`):
- `verify_digest` unit tests: match, case-insensitive, mismatch, unsupported algorithm, malformed.
- `wiremock` integration tests for `download_blob`: **rejects digest mismatch**, **rejects size mismatch** (partial file deleted in both), and accepts a matching digest.

## Docs
- `docs/TROUBLESHOOTING.md` Issue #17 documents the new user-facing "Blob digest/size mismatch" errors and remediation.

Fixes octasoft-ltd/wsl-ui#106 · OCT-1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)